### PR TITLE
Activate lto for release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ env_logger = "0.7"
 strum = "0.18"
 strum_macros = "0.18"
 # termcolor = "1.0"
+
+[profile.release]
+lto = true
+codegen-units = 1


### PR DESCRIPTION
It makes the binary quite a bit smaller and more than likely improves performance:

Before:

    -rwxr-xr-x 2 svenstaro svenstaro 5.0M Jun 26 23:23 target/release/dfrs*

After:

    -rwxr-xr-x 2 svenstaro svenstaro 3.0M Jun 26 23:24 target/release/dfrs*
