### PR TITLE
Stop hiding clippy clints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ test:
 
 lint:
 	$(CARGO) check
+	find . -name '*.rs' -exec touch {} +
 	$(CARGO) clippy --all -- \
 		-D clippy::all \
 		-D clippy::pedantic \


### PR DESCRIPTION
When running cargo check first and then cargo clippy, cargo clippy won't do anything at all because it won't detect any changed files and won't run. The `find` is a workable stopgap solution until this gets fixed in some way in clippy upstream.