### PR TITLE
Put clippy lint definitions into main.rs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,16 +38,7 @@ test:
 
 lint:
 	$(CARGO) check
-	$(CARGO) clippy --all -- \
-		-D clippy::all \
-		-D clippy::pedantic \
-		-D clippy::restriction \
-		-D clippy::correctness \
-		-D clippy::complexity \
-		-D clippy::nursery \
-		-D clippy::perf \
-		-D clippy::cargo \
-		-D warnings
+	$(CARGO) clippy --all -- -D warnings
 
 docs: man completions
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(clippy::all, clippy::restriction, clippy::nursery, clippy::pedantic, clippy::cargo)]
 extern crate anyhow;
 extern crate strum;
 extern crate strum_macros;


### PR DESCRIPTION
This ensures that whether users run `make lint` or straight `cargo clippy`, it'll always run the same set of lints.

You'll notice that I erased some explicit lints. That's because they should already be covered by `clippy::all`. I left those that aren't covered by `clippy::all`. See https://github.com/rust-lang/rust-clippy.