### PR TITLE
Refactor Vec<&MountEntry> to Vec<MountEntry>

### DIFF
--- a/src/mount.rs
+++ b/src/mount.rs
@@ -4,6 +4,7 @@ use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;
 
+#[derive(Clone)]
 pub struct MountEntry {
     pub mnt_fsname: String,
     pub mnt_dir: String,


### PR DESCRIPTION
This breaks up some of the iterator complexity and moves some inline closures into functions to make it easier to read/test. Running `dfrs` without arguments should be slightly faster, if it isn't you could try replacing `#[inline]` with `#[inline(always)]`.